### PR TITLE
fix: atualiza libwebkit2gtk-4.0-dev para 4.1-dev (Ubuntu 24.04)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install PC/SC dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+        sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 
     - name: Install frontend dependencies
       run: cd frontend && npm ci
@@ -84,7 +84,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+        sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 
     - name: Install frontend dependencies
       run: cd frontend && npm ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ go run tests/test_decode_cfs.go        # CFS decoding from known raw bytes
 make install-wails         # go install wails CLI
 make install-frontend      # cd frontend && npm install
 make install-deps-macos    # brew install pcsc-lite
-make install-deps-ubuntu   # apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+make install-deps-ubuntu   # apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 ```
 
 ## Architecture
@@ -116,7 +116,7 @@ Wails Window (native)
 - **Wails CLI** (`go install github.com/wailsapp/wails/v2/cmd/wails@latest`)
 - C compiler (`gcc` on Linux/macOS)
 - PC/SC headers: `libpcsclite-dev` (Linux) or built-in (macOS)
-- Linux also needs: `libgtk-3-dev`, `libwebkit2gtk-4.0-dev`
+- Linux also needs: `libgtk-3-dev`, `libwebkit2gtk-4.1-dev`
 - RFID hardware: ACR122U reader + MIFARE Classic 1K/4K tags
 
 ## Release & Versioning

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-wails:
 # Dependências do sistema (Ubuntu/Debian)
 install-deps-ubuntu:
 	sudo apt-get update
-	sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev
+	sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 
 # Dependências do sistema (macOS)
 install-deps-macos:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Download the latest release for your platform:
 - **Compatible RFID reader** (tested with ACR122U)
 - **PC/SC headers**:
   - macOS: built-in (no action needed)
-  - Linux: `sudo apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev`
+  - Linux: `sudo apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev`
   - Windows: built-in (winscard)
 
 #### Build Commands

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -39,7 +39,7 @@ Baixe a versao mais recente para sua plataforma:
 - **Leitor RFID compativel** (testado com ACR122U)
 - **Headers PC/SC**:
   - macOS: incluso no sistema (nenhuma acao necessaria)
-  - Linux: `sudo apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.0-dev`
+  - Linux: `sudo apt install pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev`
   - Windows: incluso no sistema (winscard)
 
 #### Comandos de Build


### PR DESCRIPTION
## Summary

- Ubuntu 24.04 (`ubuntu-latest` no GitHub Actions) removeu `libwebkit2gtk-4.0-dev`
- Wails v2 funciona com `libwebkit2gtk-4.1-dev`
- Corrige build.yml, Makefile, CLAUDE.md, README.md e README.pt-BR.md

## Test plan

- [ ] CI build passa no Ubuntu (`go test` + `wails build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)