### PR TITLE
fix: adiciona build do frontend antes dos testes no CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y pcscd libpcsclite-dev libgtk-3-dev libwebkit2gtk-4.1-dev
 
-    - name: Install frontend dependencies
-      run: cd frontend && npm ci
+    - name: Install and build frontend
+      run: cd frontend && npm ci && npm run build
 
     - name: Run tests
       run: go test ./...


### PR DESCRIPTION
## Summary

- `main.go` usa `//go:embed all:frontend/dist` que exige `frontend/dist/` na compilação
- O job `test` fazia `npm ci` (instala deps) mas não `npm run build` (gera dist/)
- `go test ./...` falhava com `pattern all:frontend/dist: no matching files found`
- Fix: troca `npm ci` por `npm ci && npm run build` no job de test

## Test plan

- [ ] CI job `test` passa (`go test ./...` compila com `frontend/dist/` presente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)