### PR TITLE
fix: adiciona build tag webkit2_41 para Linux no CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: cd frontend && npm ci && npm run build
 
     - name: Run tests
-      run: go test ./...
+      run: go test -tags webkit2_41 ./...
 
   build:
     needs: test
@@ -102,7 +102,12 @@ jobs:
 
     - name: Build with Wails
       shell: bash
-      run: wails build -ldflags "-X main.version=${{ steps.version.outputs.tag }}" -platform ${{ matrix.platform }}
+      run: |
+        EXTRA_TAGS=""
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          EXTRA_TAGS="-tags webkit2_41"
+        fi
+        wails build -ldflags "-X main.version=${{ steps.version.outputs.tag }}" -platform ${{ matrix.platform }} $EXTRA_TAGS
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Wails v2.12 no Ubuntu 24.04 precisa da build tag `webkit2_41` para usar `libwebkit2gtk-4.1`
- Sem a tag, `pkg-config` busca `webkit2gtk-4.0` que não existe no Ubuntu 24.04
- Adiciona `-tags webkit2_41` no `go test` (job test) e no `wails build` (job build, apenas Linux)

## Test plan

- [ ] CI job `test` passa no Ubuntu 24.04
- [ ] CI job `build` Linux passa (`wails build -tags webkit2_41`)
- [ ] CI job `build` macOS e Windows não são afetados (tag só aplicada no Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)