### PR TITLE
feat: adiciona instalador DMG para macOS no CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,47 @@ jobs:
         fi
         wails build -ldflags "-X main.version=${{ steps.version.outputs.tag }}" -platform ${{ matrix.platform }} $EXTRA_TAGS
 
+    - name: Create macOS DMG
+      if: runner.os == 'macOS'
+      run: |
+        brew install create-dmg librsvg
+
+        # Gerar icns a partir do SVG
+        mkdir -p iconset.iconset
+        for size in 16 32 128 256 512; do
+          rsvg-convert -w $size -h $size assets/icons/cfs-spool.svg -o iconset.iconset/icon_${size}x${size}.png
+          double=$((size * 2))
+          rsvg-convert -w $double -h $double assets/icons/cfs-spool.svg -o iconset.iconset/icon_${size}x${size}@2x.png
+        done
+        rsvg-convert -w 1024 -h 1024 assets/icons/cfs-spool.svg -o iconset.iconset/icon_512x512@2x.png
+        iconutil -c icns iconset.iconset -o app.icns
+        cp app.icns "build/bin/CFS Spool.app/Contents/Resources/app.icns"
+
+        # Gerar background do DMG
+        rsvg-convert -w 600 -h 400 assets/dmg-background.svg -o dmg-background.png
+
+        # Criar DMG com drag-to-Applications
+        create-dmg \
+          --volname "CFS Spool ${{ steps.version.outputs.tag }}" \
+          --background "dmg-background.png" \
+          --window-pos 200 120 \
+          --window-size 600 400 \
+          --icon-size 100 \
+          --icon "CFS Spool.app" 150 200 \
+          --hide-extension "CFS Spool.app" \
+          --app-drop-link 450 200 \
+          "build/bin/cfs-spool.dmg" \
+          "build/bin/CFS Spool.app"
+
+    - name: Upload macOS DMG
+      if: runner.os == 'macOS'
+      uses: actions/upload-artifact@v4
+      with:
+        name: cfs-spool-${{ matrix.name }}
+        path: build/bin/cfs-spool.dmg
+
     - name: Upload build artifacts
+      if: runner.os != 'macOS'
       uses: actions/upload-artifact@v4
       with:
         name: cfs-spool-${{ matrix.name }}
@@ -140,10 +180,8 @@ jobs:
       with:
         path: artifacts
 
-    - name: Fix binary permissions
+    - name: Fix Linux binary permissions
       run: |
-        # upload-artifact não preserva permissões Unix
-        chmod +x artifacts/cfs-spool-darwin-arm64/CFS\ Spool.app/Contents/MacOS/cfs-spool || true
         chmod +x artifacts/cfs-spool-linux-amd64/cfs-spool || true
 
     - name: Organize release files
@@ -151,9 +189,14 @@ jobs:
         mkdir -p release-files
         for dir in artifacts/cfs-spool-*/; do
           platform=$(basename "$dir")
-          cd "$dir"
-          zip -r "../../release-files/${platform}.zip" .
-          cd ../..
+          # macOS: DMG já é arquivo único, copiar direto
+          if [[ "$platform" == *darwin* ]]; then
+            cp "$dir"/*.dmg "release-files/${platform}.dmg"
+          else
+            cd "$dir"
+            zip -r "../../release-files/${platform}.zip" .
+            cd ../..
+          fi
         done
         ls -la release-files/
 
@@ -174,16 +217,15 @@ jobs:
 
           | Platform | File |
           |----------|------|
-          | macOS (Apple Silicon) | `cfs-spool-darwin-arm64.zip` |
+          | macOS (Apple Silicon) | `cfs-spool-darwin-arm64.dmg` |
           | Linux (x86_64) | `cfs-spool-linux-amd64.zip` |
           | Windows (x86_64) | `cfs-spool-windows-amd64.zip` |
 
           ### Quick Start
 
-          1. Download the ZIP for your platform
-          2. Extract and run the `cfs-spool` binary
-          3. Connect your ACR122U RFID reader
-          4. Read and write Creality filament spool tags
+          - **macOS**: Abra o DMG e arraste para Applications
+          - **Linux/Windows**: Extraia o ZIP e execute o binário `cfs-spool`
+          - Conecte o leitor ACR122U RFID
 
           ### Prerequisites
 


### PR DESCRIPTION
## Summary

- macOS agora distribui como DMG com drag-to-Applications (como na V1)
- Gera icns do SVG com rsvg-convert + iconutil
- Usa create-dmg com background customizado
- Linux e Windows continuam como ZIP

## Test plan

- [ ] CI build macOS gera DMG
- [ ] CI build Linux/Windows gera ZIP normalmente
- [ ] Release inclui `.dmg` para macOS e `.zip` para os demais

🤖 Generated with [Claude Code](https://claude.com/claude-code)