### PR TITLE
fix: adiciona codesign ad-hoc no app macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,10 @@ jobs:
         fi
         wails build -ldflags "-X main.version=${{ steps.version.outputs.tag }}" -platform ${{ matrix.platform }} $EXTRA_TAGS
 
+    - name: Ad-hoc codesign macOS app
+      if: runner.os == 'macOS'
+      run: codesign -s - --deep --force "build/bin/CFS Spool.app"
+
     - name: Create macOS DMG
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
## Summary

- Adiciona `codesign -s - --deep --force` após wails build, antes do DMG
- Sem assinatura: macOS mostra "danificado" (sem opção de permitir)
- Com ad-hoc: mostra "desenvolvedor não identificado" (pode permitir em Configurações)

🤖 Generated with [Claude Code](https://claude.com/claude-code)