### PR TITLE
feat: adiciona filamentos System ausentes do database da K2 Plus

### DIFF
--- a/app_options.go
+++ b/app_options.go
@@ -66,6 +66,7 @@ var materials = []MaterialOption{
 	// Materiais Creality (códigos 01xxx-29xxx) — Vendor "0276"
 	{"01001", "Hyper PLA", "0276"},
 	{"01002", "Hyper L-W PLA", "0276"},
+	{"01003", "Hyper Luminous", "0276"},
 	{"01004", "Hyper Stardust", "0276"},
 	{"01601", "Soleyin Ultra PLA", "0276"},
 	{"02001", "Hyper PLA-CF", "0276"},
@@ -76,6 +77,7 @@ var materials = []MaterialOption{
 	{"06002", "Hyper PETG", "0276"},
 	{"06003", "Hyper PETG-CF", "0276"},
 	{"06004", "Hyper PETG-GF", "0276"},
+	{"06005", "Soleyin Basic PETG", "0276"},
 	{"07001", "CR-ABS", "0276"},
 	{"07002", "Hyper PC", "0276"},
 	{"08001", "Ender-PLA", "0276"},
@@ -106,6 +108,10 @@ var materials = []MaterialOption{
 	{"E1006", "eSUN PLA-HS", "ESUN"},
 	{"E2001", "eSUN PETG", "ESUN"},
 	{"E2002", "eSUN PETG+HS", "ESUN"},
+	{"E2003", "eSUN PETG-Basic", "ESUN"},
+	{"E3001", "eSUN ABS+", "ESUN"},
+	{"E4001", "eSUN ASA+", "ESUN"},
+	{"E8001", "eSUN PET-Basic", "ESUN"},
 
 	// Materiais Polymaker — Vendor "POLY"
 	{"P1001", "Panchroma PLA Satin", "POLY"},

--- a/internal/creality/fields.go
+++ b/internal/creality/fields.go
@@ -269,6 +269,7 @@ func (f Fields) GetMaterialName() string {
 		// Creality
 		"01001": "Hyper PLA",
 		"01002": "Hyper L-W PLA",
+		"01003": "Hyper Luminous",
 		"01004": "Hyper Stardust",
 		"01601": "Soleyin Ultra PLA",
 		"02001": "Hyper PLA-CF",
@@ -279,6 +280,7 @@ func (f Fields) GetMaterialName() string {
 		"06002": "Hyper PETG",
 		"06003": "Hyper PETG-CF",
 		"06004": "Hyper PETG-GF",
+		"06005": "Soleyin Basic PETG",
 		"07001": "CR-ABS",
 		"07002": "Hyper PC",
 		"08001": "Ender-PLA",
@@ -308,6 +310,10 @@ func (f Fields) GetMaterialName() string {
 		"E1006": "eSUN PLA-HS",
 		"E2001": "eSUN PETG",
 		"E2002": "eSUN PETG+HS",
+		"E2003": "eSUN PETG-Basic",
+		"E3001": "eSUN ABS+",
+		"E4001": "eSUN ASA+",
+		"E8001": "eSUN PET-Basic",
 		// Polymaker
 		"P1001": "Panchroma PLA Satin",
 		"P1002": "PolySonic PLA Pro",


### PR DESCRIPTION
## Resumo

Varredura do `material_database.json` da Creality K2 Plus (via SSH) identificou 6 filamentos System oficiais que o app não reconhecia — incluindo o **eSUN ABS+** relatado pelo usuário.

## Filamentos adicionados

| Código | Nome | Brand | Tipo |
|--------|------|-------|------|
| `01003` | Hyper Luminous | Creality | PLA |
| `06005` | Soleyin Basic PETG | Creality | PETG |
| `E2003` | eSUN PETG-Basic | eSUN | PETG |
| `E3001` | eSUN ABS+ | eSUN | ABS |
| `E4001` | eSUN ASA+ | eSUN | ASA |
| `E8001` | eSUN PET-Basic | eSUN | PET |

Todos os IDs são os `base.id` oficiais do database da Creality — nenhum conflita com códigos já presentes no app.

## Mudanças

- `app_options.go`: 6 novas entradas no slice `materials` (dropdown).
- `internal/creality/fields.go`: 6 novas entradas no map de `GetMaterialName()` (nome ao ler tag).

`app.go` `convertMaterial()`, `MaterialSelect.tsx` e `SpoolForm.tsx` não precisaram de mudanças — o fluxo já trata códigos de 5 chars pass-through.

## Test plan

- [x] `go build ./...` passa
- [x] `cd frontend && npx tsc --noEmit` passa
- [x] `wails dev` — dropdowns listam os novos filamentos (Fornecedor eSUN e Creality)
- [ ] Regressão: leitura/escrita de tag com código conhecido continua funcionando (smoke test passou com gravação de blocos 4-6)