### PR TITLE
test: adiciona validações de app_options.go

### DIFF
--- a/app_options_test.go
+++ b/app_options_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+// TestMaterialCodesUnique verifica que não há códigos duplicados em `materials`.
+// Códigos duplicados quebram a filtragem por vendor e o lookup por Code, gerando
+// comportamento inconsistente nos dropdowns e na gravação da tag.
+func TestMaterialCodesUnique(t *testing.T) {
+	vistos := make(map[string]string, len(materials))
+	for _, m := range materials {
+		if anterior, dup := vistos[m.Code]; dup {
+			t.Errorf("código duplicado em materials: %q aparece em %q e %q", m.Code, anterior, m.Name)
+			continue
+		}
+		vistos[m.Code] = m.Name
+	}
+}
+
+// TestMaterialsVendorsConsistency verifica que todo Vendor referenciado em
+// `materials` existe em `vendors`. Sem isso, o dropdown de filtragem por vendor
+// não exibe o material correspondente.
+func TestMaterialsVendorsConsistency(t *testing.T) {
+	codigosValidos := make(map[string]struct{}, len(vendors))
+	for _, v := range vendors {
+		codigosValidos[v.Code] = struct{}{}
+	}
+
+	for _, m := range materials {
+		if _, ok := codigosValidos[m.Vendor]; !ok {
+			t.Errorf("material %q (%s) referencia vendor %q inexistente em vendors", m.Code, m.Name, m.Vendor)
+		}
+	}
+}
+
+// TestLengthsHasCustom verifica que a entrada "CUSTOM" está presente em `lengths`.
+// O frontend depende dessa entrada para exibir o campo de gramas customizado;
+// sua ausência quebra a UX de comprimentos personalizados.
+func TestLengthsHasCustom(t *testing.T) {
+	for _, l := range lengths {
+		if l.Code == "CUSTOM" {
+			return
+		}
+	}
+	t.Error("entrada com Code=\"CUSTOM\" não encontrada em lengths")
+}


### PR DESCRIPTION
Closes #26

## Summary

Adiciona 3 testes simples sobre os slices estáticos de `app_options.go` que alimentam os dropdowns do frontend.

## Testes adicionados (`app_options_test.go`)

| Teste | O que valida | Por que importa |
|-------|--------------|-----------------|
| `TestMaterialCodesUnique` | Não há `Code` duplicado em `materials` | Duplicatas quebram filtragem por vendor e lookup por código |
| `TestMaterialsVendorsConsistency` | Todo `Vendor` em `materials` existe em `vendors` | Vendor inexistente faz o material sumir no dropdown filtrado |
| `TestLengthsHasCustom` | Entrada com `Code == "CUSTOM"` existe em `lengths` | Frontend depende dela pra exibir o campo de gramas customizado |

## Resultado

```
=== RUN   TestMaterialCodesUnique
--- PASS: TestMaterialCodesUnique (0.00s)
=== RUN   TestMaterialsVendorsConsistency
--- PASS: TestMaterialsVendorsConsistency (0.00s)
=== RUN   TestLengthsHasCustom
--- PASS: TestLengthsHasCustom (0.00s)
PASS
ok  github.com/robertocorreajr/cfs_spool  0.374s
```

Suíte completa (8 testes incluindo os pré-existentes) também segue passando.

## Test plan

- [x] `go test -v ./...` — 8/8 PASS local
- [x] Pre-push hook (go build + tsc) passou
- [ ] CI (job `test` no workflow `Build and Release`) executa em runner Linux com `-tags webkit2_41` — deve passar igual

## Notas

- Estilo seguindo o padrão pré-existente em `app_test.go` (subtests com tabela, comentários e mensagens de erro em pt-BR)
- Sem mudanças em código de produção; apenas adição de arquivo de teste

🤖 Generated with [Claude Code](https://claude.com/claude-code)