### PR TITLE
test: round-trip de comprimento + cobertura dos mappers UI/RFID

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -131,3 +131,171 @@ func TestConvertDateRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestConvertLength documenta o comportamento ATUAL de convertLength.
+//
+// Atenção: a função tem um bug de short-circuit — entradas com 4 chars
+// passam direto SEM consultar o lookup. Isso significa que gramaturas
+// como "1000" e "2000" (que estão no gramMap) nunca alcançam o lookup
+// e são gravadas literalmente como código hex de 4 chars.
+// Bug rastreado na issue #39 — quando corrigida, atualizar os esperados
+// marcados com "(BUG:...)" abaixo.
+func TestConvertLength(t *testing.T) {
+	testes := []struct {
+		nome     string
+		entrada  string
+		esperado string
+	}{
+		// 4 chars: passa direto (intenção parece ser "já está em formato RFID")
+		{"4 chars passa direto", "0053", "0053"},
+		{"4 chars uppercase", "ABCD", "ABCD"},
+		{"1000g passa direto (BUG: deveria ir pro lookup gramMap)", "1000", "1000"},
+		{"2000g passa direto (BUG: deveria ir pro lookup gramMap)", "2000", "2000"},
+		{"3000g passa direto (BUG: deveria virar 03E8)", "3000", "3000"},
+		{"5000g passa direto (BUG: deveria virar 0682)", "5000", "5000"},
+
+		// Lookup cm pré-definido (4 chars com prefixo 0)
+		// Nota: "0083", "0165", "0330", "0660" também têm 4 chars, então passam direto.
+		// O lookup lengthMap nunca é alcançado pelo código atual.
+		{"0083 passa direto (4 chars, NAO consulta lengthMap)", "0083", "0083"},
+		{"0165 passa direto (4 chars, NAO consulta lengthMap)", "0165", "0165"},
+		{"0330 passa direto (4 chars, NAO consulta lengthMap)", "0330", "0330"},
+		{"0660 passa direto (4 chars, NAO consulta lengthMap)", "0660", "0660"},
+
+		// Lookup gramas pré-definido (3 chars, alcança gramMap)
+		{"250g vira 0053", "250", "0053"},
+		{"500g vira 00A5", "500", "00A5"},
+
+		// Custom: cm = gramas/3 → hex (entradas com 5+ chars)
+		{"10000g vira 0D05 (3333cm)", "10000", "0D05"},
+		{"15000g vira 1388 (5000cm)", "15000", "1388"},
+
+		// Overflow: cap em 65535 cm
+		{"200000g cap em FFFF", "200000", "FFFF"},
+		{"196605g (65535*3) bate exato em FFFF", "196605", "FFFF"},
+
+		// Inválidos: fallback "0053"
+		{"vazio fallback (0 chars)", "", "0053"},
+		{"texto invalido fallback (3 chars)", "abc", "0053"},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			resultado := convertLength(tt.entrada)
+			if resultado != tt.esperado {
+				t.Errorf("convertLength(%q) = %q, esperado %q", tt.entrada, resultado, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestConvertMaterial cobre os 3 caminhos: já em código (5 chars passa direto),
+// nome conhecido (lookup), nome desconhecido (passa direto como fallback).
+func TestConvertMaterial(t *testing.T) {
+	testes := []struct {
+		nome     string
+		entrada  string
+		esperado string
+	}{
+		{"codigo de 5 chars passa direto", "00001", "00001"},
+		{"codigo eSUN passa direto", "E1001", "E1001"},
+		{"codigo Polymaker passa direto", "P1001", "P1001"},
+		{"PLA generico", "PLA", "00001"},
+		{"Hyper PLA Creality", "Hyper PLA", "01001"},
+		{"eSUN PLA+", "eSUN PLA+", "E1001"},
+		{"PolySonic PLA", "PolySonic PLA", "P1004"},
+		{"desconhecido passa direto", "Material X", "Material X"},
+		{"vazio passa direto", "", ""},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			resultado := convertMaterial(tt.entrada)
+			if resultado != tt.esperado {
+				t.Errorf("convertMaterial(%q) = %q, esperado %q", tt.entrada, resultado, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestVendorToSupplier confirma que apenas "0000" mapeia para genérico;
+// qualquer outro vendor (Creality, eSUN, Polymaker) vira "0276" no RFID.
+func TestVendorToSupplier(t *testing.T) {
+	testes := []struct {
+		nome     string
+		entrada  string
+		esperado string
+	}{
+		{"generico", "0000", "0000"},
+		{"Creality", "0276", "0276"},
+		{"eSUN vira 0276 no RFID", "ESUN", "0276"},
+		{"Polymaker vira 0276 no RFID", "POLY", "0276"},
+		{"vazio vira 0276 (default)", "", "0276"},
+		{"desconhecido vira 0276", "XYZ", "0276"},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			resultado := vendorToSupplier(tt.entrada)
+			if resultado != tt.esperado {
+				t.Errorf("vendorToSupplier(%q) = %q, esperado %q", tt.entrada, resultado, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestMaterialToVendor cobre os 4 caminhos:
+// - prefixo E → "ESUN"
+// - prefixo P → "POLY"
+// - código numérico no range 01000-29999 → "0276" (Creality)
+// - resto → "0000" (genérico)
+func TestMaterialToVendor(t *testing.T) {
+	testes := []struct {
+		nome     string
+		entrada  string
+		esperado string
+	}{
+		{"prefixo E (eSUN)", "E1001", "ESUN"},
+		{"prefixo P (Polymaker)", "P1001", "POLY"},
+		{"limite inferior Creality (01000)", "01000", "0276"},
+		{"meio do range Creality (15001)", "15001", "0276"},
+		{"limite superior Creality (29999)", "29999", "0276"},
+		{"abaixo do range (00001 generico)", "00001", "0000"},
+		{"acima do range (30000 generico)", "30000", "0000"},
+		{"vazio vira generico", "", "0000"},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			resultado := materialToVendor(tt.entrada)
+			if resultado != tt.esperado {
+				t.Errorf("materialToVendor(%q) = %q, esperado %q", tt.entrada, resultado, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestVendorName cobre os 4 vendors conhecidos e o fallback "(desconhecido)".
+func TestVendorName(t *testing.T) {
+	testes := []struct {
+		nome     string
+		entrada  string
+		esperado string
+	}{
+		{"Creality", "0276", "Creality"},
+		{"Generico", "0000", "Genérico"},
+		{"eSUN", "ESUN", "eSUN"},
+		{"Polymaker", "POLY", "Polymaker"},
+		{"desconhecido", "XYZ", "XYZ (desconhecido)"},
+		{"vazio", "", " (desconhecido)"},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			resultado := vendorName(tt.entrada)
+			if resultado != tt.esperado {
+				t.Errorf("vendorName(%q) = %q, esperado %q", tt.entrada, resultado, tt.esperado)
+			}
+		})
+	}
+}

--- a/internal/creality/fields.go
+++ b/internal/creality/fields.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -229,6 +230,33 @@ func (f Fields) FormatLength() string {
 	default:
 		return f.Length + "cm"
 	}
+}
+
+// DecodeLengthToGrams é a função inversa do convertLength em app.go.
+// Para os 4 valores pré-definidos retorna a gramatura exata; para valores
+// custom converte cm hexadecimal para gramas multiplicando por 3.
+//
+// Limitação conhecida: o encoding cm = gramas/3 perde precisão (truncamento)
+// para gramaturas que não são múltiplos de 3. O round-trip preserva valores
+// exatos apenas quando gramas % 3 == 0.
+func DecodeLengthToGrams(lengthHex string) (int, error) {
+	// Lookup inverso para os 4 valores pré-definidos (preserva gramatura exata)
+	predefinidos := map[string]int{
+		"0053": 250,
+		"00A5": 500,
+		"014A": 1000,
+		"0294": 2000,
+	}
+	if g, ok := predefinidos[strings.ToUpper(lengthHex)]; ok {
+		return g, nil
+	}
+
+	// Caso geral: hex → cm → gramas (cm * 3)
+	cm, err := strconv.ParseUint(lengthHex, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("comprimento hex inválido: %q: %w", lengthHex, err)
+	}
+	return int(cm) * 3, nil
 }
 
 // GetMaterialName retorna o nome do material baseado no código

--- a/internal/creality/fields_test.go
+++ b/internal/creality/fields_test.go
@@ -1,6 +1,9 @@
 package creality
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // TestFormatDate documenta o comportamento ATUAL de FormatDate.
 //
@@ -197,6 +200,126 @@ func TestIsBlankTag(t *testing.T) {
 			resultado := f.IsBlankTag()
 			if resultado != tt.esperado {
 				t.Errorf("IsBlankTag() para tag %+v = %v, esperado %v", f, resultado, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestDecodeLengthToGrams cobre os 4 valores pré-definidos (preservam
+// gramatura exata via lookup), valores custom (cm * 3) e hex inválido.
+func TestDecodeLengthToGrams(t *testing.T) {
+	testes := []struct {
+		nome     string
+		hex      string
+		ok       bool
+		esperado int
+	}{
+		// Pré-definidos (lookup direto, gramatura exata)
+		{"250g (0053)", "0053", true, 250},
+		{"500g (00A5)", "00A5", true, 500},
+		{"1kg (014A)", "014A", true, 1000},
+		{"2kg (0294)", "0294", true, 2000},
+		{"lookup case-insensitive", "00a5", true, 500},
+
+		// Custom (cm * 3)
+		{"3kg custom (03E8 = 1000cm)", "03E8", true, 3000},
+		{"5kg custom (0682 = 1666cm trunca de 5000/3)", "0682", true, 4998},
+		{"10kg custom (0D05 = 3333cm)", "0D05", true, 9999},
+		{"saturado (FFFF = 65535cm)", "FFFF", true, 196605},
+		{"zero (0000)", "0000", true, 0},
+
+		// Inválidos
+		{"hex com Z", "00ZZ", false, 0},
+		{"vazio", "", false, 0},
+		{"hex muito longo", "DEADBEEF1", false, 0}, // > 32 bits
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			gramas, err := DecodeLengthToGrams(tt.hex)
+			if tt.ok && err != nil {
+				t.Fatalf("erro inesperado para %q: %v", tt.hex, err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatalf("esperava erro para %q, recebeu %d", tt.hex, gramas)
+			}
+			if tt.ok && gramas != tt.esperado {
+				t.Errorf("DecodeLengthToGrams(%q) = %d, esperado %d", tt.hex, gramas, tt.esperado)
+			}
+		})
+	}
+}
+
+// TestLengthRoundTripCripto valida o round-trip completo do comprimento:
+// gramas → convertLength (em app.go, simulado aqui) → ASCIIConcat → encrypt
+// → decrypt → ParseFields → DecodeLengthToGrams → gramas.
+//
+// Para gramaturas múltiplas de 3 (ou pré-definidas), o valor é preservado
+// exato. Caso contrário, há perda de até 2g devido ao truncamento integer
+// na conversão cm = gramas/3.
+func TestLengthRoundTripCripto(t *testing.T) {
+	// Aqui replicamos a lógica de app.convertLength para custom (cm = gramas/3)
+	encodeCustom := func(gramas int) string {
+		cm := min(gramas/3, 65535)
+		return fmt.Sprintf("%04X", cm)
+	}
+
+	testes := []struct {
+		nome    string
+		entrada string // código hex direto a injetar em fields.Length
+		esperado int
+	}{
+		{"pre-definido 250g", "0053", 250},
+		{"pre-definido 500g", "00A5", 500},
+		{"pre-definido 1kg", "014A", 1000},
+		{"pre-definido 2kg", "0294", 2000},
+		{"custom 3kg multiplo de 3", encodeCustom(3000), 3000},
+		{"custom 9kg multiplo de 3", encodeCustom(9000), 9000},
+	}
+
+	for _, tt := range testes {
+		t.Run(tt.nome, func(t *testing.T) {
+			f := Fields{
+				Batch:    "A2",
+				Date:     "10524",
+				Supplier: "0276",
+				Material: "01001",
+				Color:    "0FF4010",
+				Length:   tt.entrada,
+				Serial:   "000001",
+				Reserve:  "0000",
+			}
+
+			ascii, err := f.ASCIIConcat()
+			if err != nil {
+				t.Fatalf("ASCIIConcat: %v", err)
+			}
+
+			b4, b5, b6, err := EncryptPayloadToBlocks(ascii)
+			if err != nil {
+				t.Fatalf("EncryptPayloadToBlocks: %v", err)
+			}
+
+			plain, err := DecryptBlocks(b4 + b5 + b6)
+			if err != nil {
+				t.Fatalf("DecryptBlocks: %v", err)
+			}
+
+			parsed, err := ParseFields(plain)
+			if err != nil {
+				t.Fatalf("ParseFields: %v", err)
+			}
+
+			if parsed.Length != tt.entrada {
+				t.Errorf("Length apos round-trip = %q, esperado %q", parsed.Length, tt.entrada)
+			}
+
+			gramas, err := DecodeLengthToGrams(parsed.Length)
+			if err != nil {
+				t.Fatalf("DecodeLengthToGrams: %v", err)
+			}
+			if gramas != tt.esperado {
+				t.Errorf("gramas apos round-trip = %d, esperado %d", gramas, tt.esperado)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #23

Surfaces #39 (bug de short-circuit em `convertLength` encontrado durante a escrita dos testes)

## Summary

Cobre todos os 5 itens da issue #23 (P0 — motivador original do inventário de testes). Inclui **uma nova função de produção** (`DecodeLengthToGrams`) que era pré-requisito explícito da issue para fechar o round-trip de comprimento.

## Novo código de produção

**`internal/creality/fields.go`** — `DecodeLengthToGrams(lengthHex string) (int, error)`:
- Lookup direto dos 4 valores pré-definidos (`0053`, `00A5`, `014A`, `0294`) → preserva gramatura exata (250, 500, 1000, 2000g)
- Fallback geral: `cm * 3` (inverso de `convertLength`)
- Limitação documentada: gramaturas que **não** são múltiplas de 3 perdem até 2g por truncamento integer no encode

## Cobertura de testes

| Função | Subtests | Cobre |
|--------|----------|-------|
| `convertLength` (app.go) | 19 | lookup cm/gramas pré-def, custom, overflow (cap FFFF), inválidos. Documenta bug #39 |
| `convertMaterial` (app.go) | 9 | codes 5-char passa direto, lookup por nome, fallback |
| `vendorToSupplier` (app.go) | 6 | apenas "0000"=genérico, outros=0276 |
| `materialToVendor` (app.go) | 8 | prefixos E/P, range Creality (01000-29999), fallback |
| `vendorName` (app.go) | 6 | 4 vendors conhecidos + fallback |
| `DecodeLengthToGrams` (creality) | 13 | pré-def exatos, custom cm*3, overflow, inválidos |
| `TestLengthRoundTripCripto` (creality) | 6 | Fields → ASCIIConcat → Encrypt → Decrypt → ParseFields → DecodeLengthToGrams |

## Bug surfaced (#39)

Encontrado: `convertLength` tem `if len(length) == 4 { return length }` no início que faz short-circuit, ignorando o lookup. Isso significa que `convertLength("1000")` devolve `"1000"` em vez de `"014A"` (apesar de existir `gramMap["1000"] = "014A"` no código abaixo). Os testes documentam o comportamento atual com `(BUG:...)` nos casos afetados; quando #39 for resolvida, atualizar os esperados.

## Resultado

```
ok  github.com/robertocorreajr/cfs_spool                    0.373s
ok  github.com/robertocorreajr/cfs_spool/internal/creality  cached
```

**Suíte total: 185 casos de teste**, todos passando.

## Test plan

- [x] `go test -v ./...` — 185/185 PASS local
- [x] Pre-push (go build + tsc) passou
- [x] Commit **sem** `[skip ci]` — adiciona função pública nova em `creality/fields.go`, então auto-tag deve disparar e gerar release com `DecodeLengthToGrams` disponível

## Notas

- A nova função é a única alteração de código de produção; tudo o mais é teste
- Testes seguem padrão pré-existente (subtests table-driven, mensagens em pt-BR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)