### PR TITLE
refactor: remove FormatDate (código morto com bug latente)

### DIFF
--- a/app.go
+++ b/app.go
@@ -169,7 +169,6 @@ func (a *App) GetVersion() string {
 type TagData struct {
 	UID          string `json:"uid"`
 	Date         string `json:"date"`         // YYYY-MM-DD para input date
-	DateDisplay  string `json:"dateDisplay"`   // formato legível pt-BR
 	SupplierCode string `json:"supplierCode"`  // código do vendor UI ("0276", "ESUN", "POLY", "0000")
 	SupplierName string `json:"supplierName"`  // "Creality", "eSUN", "Polymaker", "Genérico"
 	MaterialCode string `json:"materialCode"`  // "04001", "E1001", "P1001"
@@ -266,7 +265,6 @@ func (a *App) ReadTag() (*TagData, error) {
 	return &TagData{
 		UID:          uid,
 		Date:         parseDateToISO(fields.Date),
-		DateDisplay:  fields.FormatDate(),
 		SupplierCode: vendorCode,
 		SupplierName: vendorName(vendorCode),
 		MaterialCode: fields.Material,

--- a/internal/creality/fields.go
+++ b/internal/creality/fields.go
@@ -165,51 +165,6 @@ func (f Fields) String() string {
 		f.Batch, f.Date, f.Supplier, f.Material, f.Color, f.Length, f.Serial, f.Reserve)
 }
 
-// FormatDate converte a data do formato MDDYY para formato legível
-// BB124 = B(mês base 36) + B(dia base 36) + 1(ano 1) + 24(ano 24) = ?
-func (f Fields) FormatDate() string {
-	if len(f.Date) != 5 {
-		return f.Date + " (formato inválido)"
-	}
-	
-	// Para BB124: preciso entender o formato
-	// B em base 36 = 11
-	// B em base 36 = 11  
-	// 124 poderia ser 1/24 (janeiro 2024) ou 12/4 (dezembro 2004)?
-	
-	// Vou assumir que BB representa mês e dia em base 36
-	// E 124 representa ano (2024)
-	month := string(f.Date[0])  // B
-	day := string(f.Date[1])    // B
-	year := f.Date[2:5]         // 124
-	
-	// Conversão base 36 para decimal
-	monthNames := map[string]string{
-		"1": "Janeiro", "2": "Fevereiro", "3": "Março", "4": "Abril",
-		"5": "Maio", "6": "Junho", "7": "Julho", "8": "Agosto",
-		"9": "Setembro", "A": "Outubro", "B": "Novembro", "C": "Dezembro",
-	}
-	
-	monthName := monthNames[month]
-	if monthName == "" {
-		monthName = "Mês " + month
-	}
-	
-	// B em base 36 = 11
-	dayNum := "11"
-	if day >= "0" && day <= "9" {
-		dayNum = day
-	} else if day >= "A" && day <= "Z" {
-		// Conversão base 36: A=10, B=11, C=12, etc.
-		dayNum = fmt.Sprintf("%d", int(day[0])-int('A')+10)
-	}
-	
-	// Interpretar ano 124 como 2024
-	yearFormatted := "20" + year[1:]
-	
-	return fmt.Sprintf("%s de %s de %s", dayNum, monthName, yearFormatted)
-}
-
 // FormatColor converte a cor para formato legível
 func (f Fields) FormatColor() string {
 	if len(f.Color) == 7 && f.Color[0] == '0' {

--- a/internal/creality/fields_test.go
+++ b/internal/creality/fields_test.go
@@ -5,42 +5,6 @@ import (
 	"testing"
 )
 
-// TestFormatDate documenta o comportamento ATUAL de FormatDate.
-//
-// Atenção: a função tem um bug conhecido — extrai apenas 1 caractere do dia
-// (f.Date[1]), não 2. Isso faz com que datas como "10524" (esperado "5 de
-// Janeiro de 2024") sejam interpretadas como "0 de Janeiro de 2024".
-// Os testes abaixo refletem o comportamento atual; quando a função for
-// corrigida, atualizar os esperados aqui também.
-func TestFormatDate(t *testing.T) {
-	testes := []struct {
-		nome     string
-		date     string
-		esperado string
-	}{
-		{"mes 1 (Janeiro), 2o char dia=0", "10524", "0 de Janeiro de 2024"},
-		{"mes 9 (Setembro), 2o char dia=1", "91524", "1 de Setembro de 2024"},
-		{"mes A (Outubro), 2o char dia=2", "A2024", "2 de Outubro de 2024"},
-		{"mes B (Novembro), 2o char dia=B (=11)", "BB124", "11 de Novembro de 2024"},
-		{"mes C (Dezembro), 2o char dia=2", "C2524", "2 de Dezembro de 2024"},
-		{"mes desconhecido Z, 2o char dia=0", "Z0123", "0 de Mês Z de 2023"},
-		{"dia base 36 (Z=35), mes 1", "1Z124", "35 de Janeiro de 2024"},
-		{"date vazia", "", " (formato inválido)"},
-		{"date curta", "12", "12 (formato inválido)"},
-		{"date longa", "123456", "123456 (formato inválido)"},
-	}
-
-	for _, tt := range testes {
-		t.Run(tt.nome, func(t *testing.T) {
-			f := Fields{Date: tt.date}
-			resultado := f.FormatDate()
-			if resultado != tt.esperado {
-				t.Errorf("FormatDate(%q) = %q, esperado %q", tt.date, resultado, tt.esperado)
-			}
-		})
-	}
-}
-
 // TestFormatColor cobre cor válida (7 chars, começando com 0) e variações
 // que devem retornar a cor crua sem formatação hex.
 func TestFormatColor(t *testing.T) {

--- a/tests/test_decode_cfs.go
+++ b/tests/test_decode_cfs.go
@@ -81,7 +81,7 @@ func main() {
 			fmt.Printf("Erro ao fazer parse: %v\n", err)
 		} else {
 			fmt.Printf("Lote (fixo): %s\n", fields.Batch)
-			fmt.Printf("Data: %s (%s)\n", fields.Date, fields.FormatDate())
+			fmt.Printf("Data: %s (formato YYMDD)\n", fields.Date)
 			fmt.Printf("Fornecedor: %s (%s)\n", fields.Supplier, fields.GetSupplierName())
 			fmt.Printf("Material: %s (%s)\n", fields.Material, fields.GetMaterialName())
 			fmt.Printf("Cor: %s (%s)\n", fields.Color, fields.FormatColor())

--- a/tests/test_read_diagnosis.go
+++ b/tests/test_read_diagnosis.go
@@ -119,7 +119,7 @@ func main() {
 		} else {
 			fmt.Println("✅ Campos parseados com sucesso:")
 			fmt.Printf("   Lote (fixo): %s\n", fields.Batch)
-			fmt.Printf("   Date: %s (%s)\n", fields.Date, fields.FormatDate())
+			fmt.Printf("   Date: %s (formato YYMDD)\n", fields.Date)
 			fmt.Printf("   Supplier: %s (%s)\n", fields.Supplier, fields.GetSupplierName())
 			fmt.Printf("   Material: %s (%s)\n", fields.Material, fields.GetMaterialName())
 			fmt.Printf("   Color: %s (%s)\n", fields.Color, fields.FormatColor())


### PR DESCRIPTION
Closes #36

## Summary

`FormatDate` em `internal/creality/fields.go` assumia um formato `MDDYY` que **não existe no app** — o formato real é `YYMDD` (gerado por `convertDate` em `app.go`, lido por `parseDateToISO`). Resultado: a função exibia datas absurdas (ex: `"2024-01-05"` saía como `"1 de Fevereiro de 2005"`).

Investigação confirmou que é **código morto**:
- Frontend (`SpoolForm.tsx`) usa apenas `data.date` (vem de `parseDateToISO`, correto)
- `TagData.DateDisplay` (preenchido por `FormatDate`) nunca foi lido pelo JS
- Únicos chamadores reais eram scripts de debug em `tests/`

Em vez de reescrever a função, **removo** ela e os artefatos associados.

## Mudanças

- `internal/creality/fields.go`: remove método `FormatDate`
- `app.go`: remove campo `DateDisplay` do struct `TagData` e do struct literal de `ReadTag`
- `internal/creality/fields_test.go`: remove `TestFormatDate` (10 subtests)
- `tests/test_decode_cfs.go` / `tests/test_read_diagnosis.go`: imprimem `fields.Date` cru com nota `(formato YYMDD)` — não dependem mais de função de formatação

## Impacto

| Onde | Antes | Depois |
|------|-------|--------|
| Tag física (gravação) | ✅ Correto (via `convertDate`) | ✅ Correto |
| Tag física (leitura) | ✅ Correto (via `parseDateToISO`) | ✅ Correto |
| Frontend UI (`Date`) | ✅ Correto | ✅ Correto |
| API response field `dateDisplay` | ❌ Sempre errado, nunca lido | 🗑️ Removido |
| Scripts de debug | ❌ Imprimiam errado | ✅ Imprimem cru |

## Resultado

Suíte: **174 casos** passando (eram 185, perdemos os 10 de `TestFormatDate` removidos).

```
ok  github.com/robertocorreajr/cfs_spool                    0.381s
ok  github.com/robertocorreajr/cfs_spool/internal/creality  0.683s
```

## Test plan

- [x] `go test -v ./...` — 174/174 PASS
- [x] Pre-push (go build + tsc) passou
- [x] Commit **sem** `[skip ci]` — remove campo público `dateDisplay` do JSON da API (mudança de contrato, mesmo que ninguém use). Auto-tag + build + release nova com a remoção propagada

## Notas

- O campo `dateDisplay` na resposta JSON deixa de existir. Como confirmamos via grep que **o frontend nunca lê** esse campo, a remoção é segura. Eventuais consumidores externos (caso existam) continuam tendo `date` no formato ISO `YYYY-MM-DD`, que é o canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)