### PR TITLE
ci: roda testes Go + frontend em pre-push e auto-tag (#29)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Hook pre-push: garante compilação + testes antes de enviar.
+#
+# Para ativar este hook localmente, rode uma vez:
+#   make install-hooks
+# (equivale a: git config core.hooksPath .githooks)
+
+set -e
+
+echo "🔍 Verificando compilação Go..."
+if ! go build ./... 2>&1; then
+    echo "❌ Erro na compilação Go. Push cancelado."
+    exit 1
+fi
+
+echo "🔍 Verificando TypeScript..."
+if ! (cd frontend && npx tsc --noEmit 2>&1); then
+    echo "❌ Erro no TypeScript. Push cancelado."
+    exit 1
+fi
+
+echo "🧪 Rodando testes Go..."
+if ! go test ./... 2>&1; then
+    echo "❌ Testes Go falharam. Push cancelado."
+    exit 1
+fi
+
+echo "🧪 Rodando testes do frontend..."
+if ! (cd frontend && npm test --silent 2>&1); then
+    echo "❌ Testes do frontend falharam. Push cancelado."
+    exit 1
+fi
+
+echo "✅ Build + testes OK. Prosseguindo com push."

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -35,7 +35,32 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-      
+
+      - name: Instalar dependências de sistema (PC/SC)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpcsclite-dev
+
+      - name: Configurar Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Instalar dependências do frontend
+        run: cd frontend && npm ci
+
+      - name: Rodar testes (Go + frontend)
+        run: |
+          make test
+          make test-frontend
+
       - name: Determinar incremento de versão
         id: increment_type
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # CFS Spool Makefile — Wails v2
 VERSION ?= dev
 
-.PHONY: all dev build build-all test clean install-frontend install-wails install-deps-ubuntu install-deps-macos help
+.PHONY: all dev build build-all test test-frontend test-all clean install-frontend install-wails install-hooks install-deps-ubuntu install-deps-macos help
 
 # Default target
 all: build
@@ -21,9 +21,16 @@ build-all:
 	wails build -platform linux/amd64 -ldflags "-X main.version=$(VERSION)"
 	wails build -platform windows/amd64 -ldflags "-X main.version=$(VERSION)"
 
-# Testes
+# Testes (Go)
 test:
 	go test -v ./...
+
+# Testes (frontend)
+test-frontend:
+	cd frontend && npm test
+
+# Roda toda a suíte (Go + frontend)
+test-all: test test-frontend
 
 # Limpar artefatos
 clean:
@@ -36,6 +43,11 @@ install-frontend:
 # Instalar Wails CLI
 install-wails:
 	go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+# Configurar git para usar os hooks versionados em .githooks/
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "Hooks instalados a partir de .githooks/"
 
 # Dependências do sistema (Ubuntu/Debian)
 install-deps-ubuntu:
@@ -54,8 +66,11 @@ help:
 	@echo "  dev              - Desenvolvimento com hot-reload"
 	@echo "  build            - Build para plataforma atual"
 	@echo "  build-all        - Build para todas as plataformas"
-	@echo "  test             - Executar testes"
+	@echo "  test             - Executar testes Go"
+	@echo "  test-frontend    - Executar testes do frontend (Vitest)"
+	@echo "  test-all         - Executar Go + frontend"
 	@echo "  clean            - Limpar artefatos"
 	@echo "  install-frontend - Instalar dependências do frontend"
 	@echo "  install-wails    - Instalar Wails CLI"
+	@echo "  install-hooks    - Configurar git para usar .githooks/"
 	@echo "  install-deps-*   - Instalar dependências do sistema"


### PR DESCRIPTION
Resolve a issue #29 — integração de testes ao pre-push e ao workflow de auto-tag.

## Makefile

- `make test-frontend` — `cd frontend && npm test` (Vitest run).
- `make test-all` — atalho para `test` + `test-frontend`.
- `make install-hooks` — `git config core.hooksPath .githooks`.

## .githooks/pre-push (novo, versionado)

Hook completo: `go build` → `tsc --noEmit` → `go test ./...` → `npm test`. Falha qualquer etapa, push é cancelado.

Para ativar localmente (uma vez por clone): `make install-hooks`. O `.git/hooks/pre-push` local atual continua funcionando — o arquivo em `.githooks/` é a versão canônica para novos clones.

## .github/workflows/auto-tag.yml

Adiciona, antes do step de versionamento:

1. `apt install libpcsclite-dev` (CGO + scard).
2. `actions/setup-go@v5` (Go 1.24).
3. `actions/setup-node@v4` (Node 20, cache npm).
4. `cd frontend && npm ci`.
5. `make test && make test-frontend`.

Commits com `[skip ci]` continuam pulando o workflow inteiro (comportamento padrão do GitHub Actions).

## Test plan

- [x] `make test` ok (Go).
- [x] `make test-frontend` ok (5 files, 23 tests).
- [x] `.githooks/pre-push` executa e termina com "✅ Build + testes OK".
- [x] `npx js-yaml` valida o YAML do workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)