### PR TITLE
refactor: factory mockável de scard.Context (#50)

### DIFF
--- a/internal/rfid/pcsc.go
+++ b/internal/rfid/pcsc.go
@@ -1,0 +1,73 @@
+package rfid
+
+// Camada fina sobre github.com/ebfe/scard para permitir mock em testes.
+// Apenas os métodos efetivamente usados por Reader.Open()/Close() são
+// expostos pelas interfaces — abstrair GetStatusChange/ReaderState (usado
+// pelo watcher em app.go) ficou deliberadamente de fora desta camada para
+// não inflar o blast radius.
+
+import "github.com/ebfe/scard"
+
+// pcscContext é a interface mínima exposta a Reader.Open(); em produção
+// é um wrapper sobre *scard.Context (ver scardContext) e em testes é
+// um fake controlável.
+type pcscContext interface {
+	ListReaders() ([]string, error)
+	Connect(reader string) (pcscCard, error)
+	Release() error
+}
+
+// pcscCard é a interface mínima exposta para um cartão conectado.
+type pcscCard interface {
+	Transmit(cmd []byte) ([]byte, error)
+	Disconnect() error
+}
+
+// pcscFactory abre um contexto PC/SC. Sobrescritível em testes via
+// `defaultPCSCFactory = ...`.
+type pcscFactory func() (pcscContext, error)
+
+// defaultPCSCFactory é o ponto de extensão usado por Reader.Open().
+// Em produção fala com o serviço PC/SC real; em testes é trocado por
+// uma factory que devolve um fake de pcscContext.
+var defaultPCSCFactory pcscFactory = realPCSCFactory
+
+// realPCSCFactory abre o contexto via scard.EstablishContext e o
+// embrulha em scardContext.
+func realPCSCFactory() (pcscContext, error) {
+	ctx, err := scard.EstablishContext()
+	if err != nil {
+		return nil, err
+	}
+	return &scardContext{ctx: ctx}, nil
+}
+
+// scardContext envolve *scard.Context para satisfazer pcscContext.
+type scardContext struct{ ctx *scard.Context }
+
+func (s *scardContext) ListReaders() ([]string, error) {
+	return s.ctx.ListReaders()
+}
+
+func (s *scardContext) Connect(reader string) (pcscCard, error) {
+	card, err := s.ctx.Connect(reader, scard.ShareShared, scard.ProtocolAny)
+	if err != nil {
+		return nil, err
+	}
+	return &scardCard{card: card}, nil
+}
+
+func (s *scardContext) Release() error {
+	return s.ctx.Release()
+}
+
+// scardCard envolve *scard.Card para satisfazer pcscCard.
+type scardCard struct{ card *scard.Card }
+
+func (s *scardCard) Transmit(cmd []byte) ([]byte, error) {
+	return s.card.Transmit(cmd)
+}
+
+func (s *scardCard) Disconnect() error {
+	return s.card.Disconnect(scard.LeaveCard)
+}

--- a/internal/rfid/pcsc_test.go
+++ b/internal/rfid/pcsc_test.go
@@ -1,0 +1,211 @@
+package rfid
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakePCSCContext implementa pcscContext para testes — controla
+// determinísticamente o resultado de cada método chamado por Open()/Close().
+type fakePCSCContext struct {
+	listReadersResult []string
+	listReadersErr    error
+	connectErr        error
+	connectFn         func(reader string) (pcscCard, error)
+	releaseErr        error
+
+	listReadersCalled int
+	connectCalled     int
+	releaseCalled     int
+
+	connectedReaders []string // capturados para verificar qual reader foi escolhido
+}
+
+func (f *fakePCSCContext) ListReaders() ([]string, error) {
+	f.listReadersCalled++
+	return f.listReadersResult, f.listReadersErr
+}
+
+func (f *fakePCSCContext) Connect(reader string) (pcscCard, error) {
+	f.connectCalled++
+	f.connectedReaders = append(f.connectedReaders, reader)
+	if f.connectFn != nil {
+		return f.connectFn(reader)
+	}
+	if f.connectErr != nil {
+		return nil, f.connectErr
+	}
+	return &fakePCSCCard{}, nil
+}
+
+func (f *fakePCSCContext) Release() error {
+	f.releaseCalled++
+	return f.releaseErr
+}
+
+// fakePCSCCard implementa pcscCard.
+type fakePCSCCard struct {
+	transmitResp     []byte
+	transmitErr      error
+	transmitCalls    [][]byte
+	disconnectCalled int
+	disconnectErr    error
+}
+
+func (f *fakePCSCCard) Transmit(cmd []byte) ([]byte, error) {
+	f.transmitCalls = append(f.transmitCalls, append([]byte(nil), cmd...))
+	return f.transmitResp, f.transmitErr
+}
+
+func (f *fakePCSCCard) Disconnect() error {
+	f.disconnectCalled++
+	return f.disconnectErr
+}
+
+// withFactory substitui defaultPCSCFactory pelo fake e devolve uma
+// função para restaurar o original — uso típico via `defer`.
+func withFactory(t *testing.T, f pcscFactory) func() {
+	t.Helper()
+	original := defaultPCSCFactory
+	defaultPCSCFactory = f
+	return func() { defaultPCSCFactory = original }
+}
+
+// TestOpen_FactoryFalha verifica propagação de erro da factory.
+func TestOpen_FactoryFalha(t *testing.T) {
+	want := errors.New("EstablishContext falhou")
+	defer withFactory(t, func() (pcscContext, error) {
+		return nil, want
+	})()
+
+	r, err := Open()
+	if err == nil || err.Error() != want.Error() {
+		t.Errorf("Open() erro = %v, esperado %v", err, want)
+	}
+	if r != nil {
+		t.Error("Open() devolveu Reader não-nil em erro de factory")
+	}
+}
+
+// TestOpen_SemReaders cobre o caso de PC/SC sem nenhum leitor anexado.
+func TestOpen_SemReaders(t *testing.T) {
+	ctx := &fakePCSCContext{listReadersResult: []string{}}
+	defer withFactory(t, func() (pcscContext, error) { return ctx, nil })()
+
+	r, err := Open()
+	if err == nil || !strings.Contains(err.Error(), "nenhum leitor") {
+		t.Errorf("Open() erro = %v, esperado conter 'nenhum leitor'", err)
+	}
+	if r != nil {
+		t.Error("Open() devolveu Reader em ausência de leitores")
+	}
+	if ctx.releaseCalled != 1 {
+		t.Errorf("Release() chamado %d vez(es), esperado 1 (libera contexto em erro)", ctx.releaseCalled)
+	}
+}
+
+// TestOpen_ListReadersErro cobre falha ao listar leitores.
+func TestOpen_ListReadersErro(t *testing.T) {
+	ctx := &fakePCSCContext{listReadersErr: errors.New("driver indisponível")}
+	defer withFactory(t, func() (pcscContext, error) { return ctx, nil })()
+
+	r, err := Open()
+	if err == nil {
+		t.Fatal("Open() deveria falhar com erro de ListReaders")
+	}
+	if r != nil {
+		t.Error("Open() devolveu Reader em erro de ListReaders")
+	}
+	if ctx.releaseCalled != 1 {
+		t.Errorf("Release() chamado %d vez(es), esperado 1", ctx.releaseCalled)
+	}
+}
+
+// TestOpen_ConnectFalha cobre falha ao conectar no leitor encontrado.
+func TestOpen_ConnectFalha(t *testing.T) {
+	ctx := &fakePCSCContext{
+		listReadersResult: []string{"ACR122 PICC Interface"},
+		connectErr:        errors.New("cartão removido"),
+	}
+	defer withFactory(t, func() (pcscContext, error) { return ctx, nil })()
+
+	r, err := Open()
+	if err == nil || !strings.Contains(err.Error(), "cartão removido") {
+		t.Errorf("Open() erro = %v, esperado conter 'cartão removido'", err)
+	}
+	if r != nil {
+		t.Error("Open() devolveu Reader em erro de Connect")
+	}
+	if ctx.releaseCalled != 1 {
+		t.Errorf("Release() chamado %d vez(es), esperado 1", ctx.releaseCalled)
+	}
+}
+
+// TestOpen_Sucesso cobre o caminho feliz: ListReaders devolve um leitor,
+// Connect devolve um cartão; Reader fica utilizável e transmitFn delega
+// para o cartão devolvido.
+func TestOpen_Sucesso(t *testing.T) {
+	card := &fakePCSCCard{transmitResp: []byte{0xAA, 0x90, 0x00}}
+	ctx := &fakePCSCContext{
+		listReadersResult: []string{"ACR122 PICC Interface"},
+		connectFn:         func(string) (pcscCard, error) { return card, nil },
+	}
+	defer withFactory(t, func() (pcscContext, error) { return ctx, nil })()
+
+	r, err := Open()
+	if err != nil {
+		t.Fatalf("Open() erro inesperado: %v", err)
+	}
+	if r == nil {
+		t.Fatal("Open() devolveu Reader nil")
+	}
+	if ctx.connectCalled != 1 {
+		t.Errorf("Connect chamado %d vez(es), esperado 1", ctx.connectCalled)
+	}
+	if len(ctx.connectedReaders) != 1 || ctx.connectedReaders[0] != "ACR122 PICC Interface" {
+		t.Errorf("reader conectado = %v, esperado [ACR122 PICC Interface]", ctx.connectedReaders)
+	}
+
+	// transmitFn deve delegar para o card devolvido pela factory.
+	resp, err := r.transmit([]byte{0xFF, 0xCA, 0x00, 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("transmit falhou: %v", err)
+	}
+	if !bytes.Equal(resp, []byte{0xAA, 0x90, 0x00}) {
+		t.Errorf("resposta transmit = %X, esperado AA9000", resp)
+	}
+	if len(card.transmitCalls) != 1 {
+		t.Errorf("Card.Transmit chamado %d vez(es), esperado 1", len(card.transmitCalls))
+	}
+}
+
+// TestClose_LiberaCardEContexto verifica que Close chama Disconnect e
+// Release exatamente uma vez quando ambos foram inicializados.
+func TestClose_LiberaCardEContexto(t *testing.T) {
+	card := &fakePCSCCard{}
+	ctx := &fakePCSCContext{}
+	r := &Reader{ctx: ctx, card: card}
+
+	r.Close()
+
+	if card.disconnectCalled != 1 {
+		t.Errorf("Disconnect chamado %d vez(es), esperado 1", card.disconnectCalled)
+	}
+	if ctx.releaseCalled != 1 {
+		t.Errorf("Release chamado %d vez(es), esperado 1", ctx.releaseCalled)
+	}
+}
+
+// TestClose_SemPanicComCamposNil garante que fechar um Reader meio-criado
+// não panica (defesa contra Open() ter falhado em algum ponto).
+func TestClose_SemPanicComCamposNil(t *testing.T) {
+	r := &Reader{} // ctx e card nil
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Errorf("Close() panicou com campos nil: %v", rec)
+		}
+	}()
+	r.Close()
+}

--- a/internal/rfid/reader.go
+++ b/internal/rfid/reader.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ebfe/scard"
 	"github.com/robertocorreajr/cfs_spool/internal/creality"
 )
 
@@ -24,27 +23,32 @@ const (
 
 // Reader mantém conexão PC/SC aberta.
 //
-// O campo transmitFn é uma indireção sobre `card.Transmit` que existe
-// para permitir testes com APDUs simulados (ver reader_test.go). Em
-// produção, Open() o inicializa com a chamada real ao cartão PC/SC.
+// Os campos ctx/card são interfaces (pcscContext/pcscCard) — em produção
+// são wrappers sobre scard.Context/Card; em testes são fakes. transmitFn
+// é uma indireção sobre card.Transmit (mantida por compatibilidade com
+// os testes que injetam APDUs sem precisar de um pcscCard completo).
 type Reader struct {
-	ctx        *scard.Context
-	card       *scard.Card
+	ctx        pcscContext
+	card       pcscCard
 	transmitFn func([]byte) ([]byte, error)
 }
 
-// Open conecta no 1º leitor encontrado (ACR122…).
+// Open conecta no 1º leitor encontrado (ACR122…). Usa
+// defaultPCSCFactory — em testes, sobrescreva essa variável de pacote
+// para injetar um pcscContext fake.
 func Open() (*Reader, error) {
-	ctx, err := scard.EstablishContext()
+	ctx, err := defaultPCSCFactory()
 	if err != nil {
 		return nil, err
 	}
 	readers, err := ctx.ListReaders()
 	if err != nil || len(readers) == 0 {
+		_ = ctx.Release()
 		return nil, errors.New("nenhum leitor PC/SC")
 	}
-	card, err := ctx.Connect(readers[0], scard.ShareShared, scard.ProtocolAny)
+	card, err := ctx.Connect(readers[0])
 	if err != nil {
+		_ = ctx.Release()
 		return nil, err
 	}
 	r := &Reader{ctx: ctx, card: card}
@@ -56,10 +60,10 @@ func Open() (*Reader, error) {
 
 func (r *Reader) Close() {
 	if r.card != nil {
-		r.card.Disconnect(scard.LeaveCard)
+		_ = r.card.Disconnect()
 	}
 	if r.ctx != nil {
-		r.ctx.Release()
+		_ = r.ctx.Release()
 	}
 }
 

--- a/internal/rfid/reader_test.go
+++ b/internal/rfid/reader_test.go
@@ -293,7 +293,78 @@ func TestDeriveKeyFromUID_FallbackEmErro(t *testing.T) {
 	}
 }
 
-// Nota: Open() abre contexto PC/SC real e não é testável sem hardware
-// (ou sem refatoração mais agressiva expondo um factory de scard.Context).
-// Os testes acima cobrem a lógica APDU de todos os métodos públicos do
-// Reader; cobrir Open()/Close() ficará para uma futura abstração.
+// TestReadRange_Sucesso cobre leitura sequencial de N blocos: cada
+// iteração consome 1 auth + 1 read.
+func TestReadRange_Sucesso(t *testing.T) {
+	bloco4 := bytes.Repeat([]byte{0x11}, 16)
+	bloco5 := bytes.Repeat([]byte{0x22}, 16)
+	fake := &fakeAPDU{queue: []apduStep{
+		{want: []byte{0xFF, 0x86}, resp: statusOK()},                                     // auth bloco 4
+		{want: []byte{0xFF, 0xB0, 0x00, 0x04, 0x10}, resp: append(bloco4, statusOK()...)}, // read bloco 4
+		{want: []byte{0xFF, 0x86}, resp: statusOK()},                                     // auth bloco 5
+		{want: []byte{0xFF, 0xB0, 0x00, 0x05, 0x10}, resp: append(bloco5, statusOK()...)}, // read bloco 5
+	}}
+	r := newReaderForTest(fake)
+
+	got, err := r.ReadRange(4, 2, KeyTypeA, "FFFFFFFFFFFF")
+	if err != nil {
+		t.Fatalf("ReadRange erro: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ReadRange devolveu %d blocos, esperado 2", len(got))
+	}
+	if got[0] != strings.ToUpper(hex.EncodeToString(bloco4)) {
+		t.Errorf("bloco 4 = %q, esperado %q", got[0], strings.ToUpper(hex.EncodeToString(bloco4)))
+	}
+	if got[1] != strings.ToUpper(hex.EncodeToString(bloco5)) {
+		t.Errorf("bloco 5 = %q, esperado %q", got[1], strings.ToUpper(hex.EncodeToString(bloco5)))
+	}
+}
+
+// TestReadRange_AbortaNaPrimeiraFalha verifica que erro na auth do
+// segundo bloco interrompe o loop e a resposta é nil.
+func TestReadRange_AbortaNaPrimeiraFalha(t *testing.T) {
+	bloco4 := bytes.Repeat([]byte{0x11}, 16)
+	fake := &fakeAPDU{queue: []apduStep{
+		{want: []byte{0xFF, 0x86}, resp: statusOK()},                                     // auth bloco 4 ok
+		{want: []byte{0xFF, 0xB0, 0x00, 0x04, 0x10}, resp: append(bloco4, statusOK()...)}, // read bloco 4 ok
+		{want: []byte{0xFF, 0x86}, resp: statusErr()},                                    // auth bloco 5 falha
+	}}
+	r := newReaderForTest(fake)
+
+	_, err := r.ReadRange(4, 2, KeyTypeA, "FFFFFFFFFFFF")
+	if err == nil {
+		t.Fatal("ReadRange deveria falhar no segundo bloco")
+	}
+}
+
+// TestWriteRange_Sucesso cobre escrita sequencial de N blocos com
+// WriteBlock simples. WriteRange só cai no método alternativo se o
+// principal falha — esse caminho fica em outro teste.
+func TestWriteRange_Sucesso(t *testing.T) {
+	fake := &fakeAPDU{queue: []apduStep{
+		{want: []byte{0xFF, 0x86}, resp: statusOK()},                  // auth bloco 4
+		{want: []byte{0xFF, 0xD6, 0x00, 0x04, 0x10}, resp: statusOK()}, // write bloco 4
+		{want: []byte{0xFF, 0x86}, resp: statusOK()},                  // auth bloco 5
+		{want: []byte{0xFF, 0xD6, 0x00, 0x05, 0x10}, resp: statusOK()}, // write bloco 5
+	}}
+	r := newReaderForTest(fake)
+
+	dados := []string{strings.Repeat("AA", 16), strings.Repeat("BB", 16)}
+	if err := r.WriteRange(4, dados, KeyTypeA, "FFFFFFFFFFFF"); err != nil {
+		t.Fatalf("WriteRange erro: %v", err)
+	}
+	if len(fake.calls) != 4 {
+		t.Errorf("esperado 4 chamadas APDU (2 blocos × auth+write), obtido %d", len(fake.calls))
+	}
+}
+
+// Nota sobre cobertura ainda em aberto:
+// - Open()/Close() agora têm cobertura via factory mock (pcsc_test.go).
+// - WriteBlockAlternative, WriteBlockDirectly, WriteTagCFS, testAuthentication,
+//   TestBasicRead, ReadRangeAlternative têm múltiplos caminhos com loops e
+//   fallbacks; testá-los exige sequências longas de APDU que tornam o teste
+//   espelho da implementação. Continuam descobertos por escolha de ROI.
+// - O watcher PC/SC em app.go::tagWatchLoop usa scard.GetStatusChange/
+//   ReaderState diretamente; abstraí-los exigiria nova camada de interfaces
+//   por cima de pcsc.go. Fora do escopo desta rodada.


### PR DESCRIPTION
Resolve a issue #50 — destrava cobertura de \`Open()\`/\`Close()\` e abre caminho para testar mais métodos do reader sem hardware.

## Refactor

\`internal/rfid/pcsc.go\` (novo):
- Interfaces \`pcscContext\` (ListReaders, Connect, Release) e \`pcscCard\` (Transmit, Disconnect).
- Wrappers concretos \`scardContext\`/\`scardCard\` sobre \`*scard.Context\`/\`*scard.Card\`.
- \`defaultPCSCFactory\` — variável de pacote, sobrescritível em testes.

\`internal/rfid/reader.go\`:
- \`Reader.ctx\`/\`Reader.card\` viram interfaces.
- \`Open()\` chama \`defaultPCSCFactory()\` e libera o contexto em erros intermediários.
- Sem mudança comportamental.

## Cobertura adicionada (10 testes novos)

\`pcsc_test.go\` (7):
- \`Open\`: factory falha; sem readers; ListReaders erro; Connect falha; happy path com transmit delegado.
- \`Close\`: libera card+ctx; não panica com campos nil.

\`reader_test.go\` (3):
- \`ReadRange\` feliz e abortando na primeira falha.
- \`WriteRange\` feliz com 2 blocos.

## Fora do escopo (registrado nos testes)

- \`WriteBlockAlternative\`/\`WriteBlockDirectly\`/\`WriteTagCFS\` — loops com fallback que tornariam o teste espelho da implementação.
- \`app.go::tagWatchLoop\` — usa \`GetStatusChange\`/\`ReaderState\` direto. Abstrair exige outra camada.

## Test plan

- [x] \`make test-all\` ok (Go + frontend, 51 + 32 testes).
- [x] \`go build ./...\` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)