### PR TITLE
ci: workflow Tests separado, [skip release] para pular só auto-tag (#55)

### DIFF
--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -10,3 +10,23 @@ Use Conventional Commits em português (pt-BR):
 - chore: tarefas de manutenção
 
 Exemplo: `feat: adiciona autenticação por OAuth`
+
+## Marcas de skip de CI
+
+Dois workflows estão configurados:
+
+- **Tests** (`.github/workflows/tests.yml`) — roda em todos os pushes/PRs e valida `make test` + `make test-frontend`. Não cria nada.
+- **Auto Tag** (`.github/workflows/auto-tag.yml`) — só roda em `main`; cria tag patch e dispara release.
+
+Convenção:
+
+- `[skip release]` no título do commit → pula apenas Auto Tag. Tests continua rodando. **Use sempre que o commit não justificar release** (test, refactor sem mudança comportamental, docs com testes que valem).
+- `[skip ci]` → pula tudo (interpretado pelo GitHub Actions). Use só em docs puros (README typo, screenshot) onde nem teste precisa rodar.
+- Sem marca → Tests + Auto Tag rodam (release nova será criada).
+
+Exemplos:
+
+- `test: adiciona cobertura de fields.go [skip release]`
+- `refactor: extrai lógica pura [skip release]`
+- `feat: adiciona check de versão` (sem marca — merece release)
+- `docs: corrige typo no README [skip ci]` (raro)

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -21,6 +21,10 @@ on:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    # Pula a criação de tag quando o commit pede [skip release].
+    # Para pular CI inteiro (incluindo o Tests), use [skip ci] — o GitHub
+    # Actions trata essa marca antes de qualquer workflow rodar.
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip release]') }}
     permissions:
       contents: write
     
@@ -36,30 +40,9 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-      - name: Instalar dependências de sistema (PC/SC)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libpcsclite-dev
-
-      - name: Configurar Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Configurar Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Instalar dependências do frontend
-        run: cd frontend && npm ci
-
-      - name: Rodar testes (Go + frontend)
-        run: |
-          make test
-          make test-frontend
+      # Os testes (Go + frontend) rodam no workflow Tests (.github/workflows/tests.yml)
+      # em todos os pushes — independente de [skip ci]/[skip release]. Aqui só geramos
+      # tag, confiando que o Tests já validou.
 
       - name: Determinar incremento de versão
         id: increment_type

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
+
+      - name: Instalar dependências de sistema (PC/SC)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpcsclite-dev
+
+      - name: Configurar Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Instalar dependências do frontend
+        run: cd frontend && npm ci
+
+      - name: Rodar testes Go
+        run: make test
+
+      - name: Rodar testes do frontend
+        run: make test-frontend


### PR DESCRIPTION
Resolve a issue #55 — separa validação de testes da criação de tag.

## Problema

\`auto-tag.yml\` misturava \"rodar testes\" + \"criar tag\". Commits com \`[skip ci]\` (convenção do repo para evitar release sem mudança comportamental) pulavam o workflow inteiro, deixando PRs de teste/refactor sem CI.

## Mudanças

### Novo workflow \`Tests\`

\`.github/workflows/tests.yml\`:
- Triggers: \`push\` em qualquer branch e \`pull_request\` para \`main\`.
- Steps: setup-go, setup-node, libpcsclite-dev, \`cd frontend && npm ci\`, \`make test\`, \`make test-frontend\`.
- Não cria tag, não publica nada.

### \`auto-tag.yml\` mais enxuto

- Remove os steps de teste (Go/Node/libpcsclite/npm/make test) — confia que \`Tests\` já validou.
- Adiciona \`if: !contains(github.event.head_commit.message, '[skip release]')\` no job, mantendo \`workflow_dispatch\` ainda permitido.

### Convenção atualizada

\`.claude/rules/commits.md\` agora documenta:

- \`[skip release]\` — pula Auto Tag, mantém Tests rodando. **Default** para commits sem mudança comportamental.
- \`[skip ci]\` — pula tudo (raro: docs puros).
- Sem marca — Tests + Auto Tag rodam.

## Pós-merge

A primeira execução do \`Tests\` vai disparar quando o workflow estiver na \`main\` (GitHub Actions registra workflows novos só depois de aparecerem na default branch).

## Test plan

- [x] \`npx js-yaml\` valida ambos os YAMLs.
- [x] Localmente \`make test-all\` passa (Go + frontend).
- [ ] Após merge, próximo push em qualquer branch dispara \`Tests\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)