### PR TITLE
docs: README dos hooks + fix do workflow Tests

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,35 @@
+# Git hooks versionados
+
+Este diretório contém os hooks Git mantidos no repositório (em vez do
+`.git/hooks/` local de cada clone).
+
+## Instalação
+
+Depois de clonar o repo, rode uma vez:
+
+```bash
+make install-hooks
+```
+
+Equivale a:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Hooks disponíveis
+
+### `pre-push`
+
+Antes de qualquer push roda, em ordem:
+
+1. `go build ./...`
+2. `cd frontend && npx tsc --noEmit`
+3. `go test ./...`
+4. `cd frontend && npm test`
+
+Se qualquer etapa falhar, o push é cancelado.
+
+A mesma cadeia roda em CI no workflow `Tests`
+(`.github/workflows/tests.yml`); o hook é a primeira linha de defesa
+local.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Instalar dependências do frontend
         run: cd frontend && npm ci
 
+      # main.go usa //go:embed all:frontend/dist — sem o build, `go test`
+      # falha em "pattern all:frontend/dist: no matching files found".
+      - name: Garantir frontend/dist (placeholder para go:embed)
+        run: |
+          mkdir -p frontend/dist
+          echo "ci-placeholder" > frontend/dist/.gitkeep
+
       - name: Rodar testes Go
         run: make test
 


### PR DESCRIPTION
Validação ponta-a-ponta da issue #55. Adiciona:

- \`.githooks/README.md\` documentando \`make install-hooks\` e o que o pre-push roda.
- Fix em \`.github/workflows/tests.yml\` — cria \`frontend/dist/.gitkeep\` antes do \`go test\` porque \`main.go\` usa \`//go:embed all:frontend/dist\` e o diretório só existe após build.

## Confirmação do Tests workflow

Run [25201918917](https://github.com/robertocorreajr/cfs_spool/actions/runs/25201918917) verde em 44s — primeiro \`Tests\` exercitado pós-merge da #55. ✅

## Skip release

PR fechada com \`[skip release]\` no merge — não muda comportamento, não precisa de tag nova.