### PR TITLE
ci: atualiza GitHub Actions para Node.js 24 (closes #42)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -30,7 +30,7 @@ jobs:
     
     steps:
       - name: Checkout código
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Necessário para obter todas as tags
           ref: main # Garantir que estamos na branch main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -62,18 +62,18 @@ jobs:
             name: windows-amd64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-tags: true
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -224,14 +224,14 @@ jobs:
 
     - name: Upload macOS DMG
       if: runner.os == 'macOS'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cfs-spool-${{ matrix.name }}
         path: build/bin/cfs-spool.dmg
 
     - name: Upload build artifacts
       if: runner.os != 'macOS'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cfs-spool-${{ matrix.name }}
         path: build/bin/*
@@ -242,7 +242,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-tags: true
         fetch-depth: 0
@@ -257,7 +257,7 @@ jobs:
         fi
 
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
 
@@ -282,7 +282,7 @@ jobs:
         ls -la release-files/
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.tag.outputs.name }}
         draft: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout código
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Instalar dependências de sistema (PC/SC)
         run: |
@@ -22,12 +22,12 @@ jobs:
           sudo apt-get install -y libpcsclite-dev
 
       - name: Configurar Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 
       - name: Configurar Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Atualiza referências de actions nos três workflows (`build.yml`, `auto-tag.yml`, `tests.yml`) para versões compatíveis com Node.js 24
- Remove warnings de deprecação do Node.js 20, que será retirado dos runners em **2026-09-16** (forçado em **2026-06-02**)
- Major pinning (`@v6` ao invés de `@v6.0.2`) para receber patches de segurança sem quebrar compatibilidade

## Versões

| Action | Antes | Depois |
|--------|-------|--------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-go` | `@v5` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `softprops/action-gh-release` | `@v1` | `@v3` |

`upload-artifact`/`download-artifact` mantêm o modelo de artefatos imutáveis introduzido no v4 — o par v7/v8 é compatível.

## Test plan

- [x] Build Go local (`go build ./...`)
- [x] Type-check frontend (`npx tsc --noEmit`)
- [x] `actionlint` passa (warnings de shellcheck pré-existentes, não relacionados)
- [ ] Workflow Tests passa no PR (validação no CI)
- [ ] Após merge: Auto Tag dispara, Build cross-platform conclui, Release publica os 3 assets, DMG macOS sai assinado e notarizado

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)