### PR TITLE
docs: corrige imprecisões na política de retenção de assets [skip release]

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -72,8 +72,9 @@ documented policy. **Tags and release notes are never deleted** — only
 the attached download artifacts may be retired.
 
 - **Policy**: [`.github/RELEASE_RETENTION.md`](../../.github/RELEASE_RETENTION.md).
-- **Cleanup workflow**: `.github/workflows/release-retention.yml` (manual
-  trigger; always start with `dry_run=true`).
+- **Cleanup workflow**: `.github/workflows/release-retention.yml` runs
+  automatically on every `release:published` event in `apply` mode. Also
+  supports `workflow_dispatch` for ad-hoc audits (default `dry_run=true`).
 - When cutting a milestone release that should keep its assets forever,
   add the tag to **both** the milestone table in `RELEASE_RETENTION.md`
   **and** the `MILESTONES` env var in the workflow, in the same PR.

--- a/.github/RELEASE_RETENTION.md
+++ b/.github/RELEASE_RETENTION.md
@@ -142,21 +142,22 @@ The workflow ([`.github/workflows/release-retention.yml`](workflows/release-rete
 
 1. Lists every release via `gh release list --limit 200`.
 2. Classifies each release as `stable`, `pre-release`, or `milestone`.
-3. Picks the 5 most recent stable releases (by published date) and
-   protects them.
+3. Picks the 5 most recent stable releases (by `createdAt`) and protects
+   them.
 4. Protects every tag listed in the milestone allowlist.
 5. For all other releases, lists their assets, deletes each via
    `gh release delete-asset`, and appends the standard retired-assets
    note to the release body if not already present.
 6. Never invokes `gh release delete` or `git tag -d`.
 
-### First run
+### First run (historical)
 
-The very first run after merging this policy will retire roughly 25
-releases worth of binaries. That is the intended one-time correction to
-align history with the policy. If you want to audit the plan before that
-happens, run the workflow once via `workflow_dispatch` with
-`dry_run=true` **before merging** (or before the next release publishes).
+The first run after this policy was merged retired ~25 releases worth of
+binaries — a one-time correction to align pre-existing history with the
+new rules. From this point on the workflow only retires what each new
+release event makes obsolete. The retroactive run was triggered manually
+via `workflow_dispatch` on 2026-05-01 (run
+[25218728884](https://github.com/robertocorreajr/cfs_spool/actions/runs/25218728884)).
 
 ### Manual restoration
 
@@ -182,5 +183,7 @@ recoverable from source.
 
 ## Change history
 
-- **2026-05-01** — Policy created (issue
-  [#63](https://github.com/robertocorreajr/cfs_spool/issues/63)).
+- **2026-05-01** — Policy created and applied retroactively (issue
+  [#63](https://github.com/robertocorreajr/cfs_spool/issues/63),
+  PR [#64](https://github.com/robertocorreajr/cfs_spool/pull/64)).
+  Workflow wired to `release:published` so future cleanups are automatic.


### PR DESCRIPTION
## Summary

Auditoria de documentação após mergear #64 e rodar a primeira limpeza retroativa identificou 3 imprecisões. Esta PR as corrige:

- **`RELEASE_RETENTION.md` "Workflow behavior"**: dizia que o workflow ordenava por "published date"; o `jq` na verdade ordena por `createdAt`. Texto atualizado para refletir o comportamento real.
- **`RELEASE_RETENTION.md` "First run"**: estava em tempo presente/futuro como se ainda fosse acontecer. Reescrita em tempo passado, com link para o run que executou a limpeza retroativa em 2026-05-01.
- **`.claude/rules/release.md`**: ainda descrevia o workflow como "manual trigger; always start with dry_run=true". Atualizado para refletir o gatilho automático em `release:published` (com `workflow_dispatch` ainda disponível para auditorias).

Também atualizei a seção "Change history" do policy doc com a referência cruzada à PR #64 e à mudança para automático.

## Test plan

- [x] Pre-push hook (`go build` + `tsc --noEmit`) passa.
- [x] Apenas mudanças de documentação — sem impacto em código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)